### PR TITLE
Add documentation for using workers-mcp with other MCP clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ For example, if your config file looks like:
     }
   }
 }
+```
 
 In Cursor, create an MCP server entry with:
 * type: `command`
@@ -106,6 +107,7 @@ For Windsurf and other MCP clients, update your configuration file to include yo
     }
   }
 }
+```
 
 Make sure to replace the placeholders with your actual server name, URL, and project path.
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,56 @@ However, if you change the names of your methods, or their parameters, or add or
 
 You shouldn't ever need to rerun `npx workers-mcp install:claude`, but it's safe to do so if you want to rule out Claude config as a source of errors.
 
+## Using with Other MCP Clients
+
+### Cursor
+
+To get your Cloudflare MCP server working in Cursor, you need to combine the 'command' and 'args' from your config file into a single string and use type 'command'.
+
+For example, if your config file looks like:
+
+```json
+{
+  "mcpServers": {
+    "your-mcp-server-name": {
+      "command": "/path/to/workers-mcp",
+      "args": [
+        "run",
+        "your-mcp-server-name",
+        "https://your-server-url.workers.dev",
+        "/path/to/your/project"
+      ],
+      "env": {}
+    }
+  }
+}
+
+In Cursor, create an MCP server entry with:
+* type: `command`
+* command: `/path/to/workers-mcp run your-mcp-server-name https://your-server-url.workers.dev /path/to/your/project`
+
+### Other MCP Clients
+
+For Windsurf and other MCP clients, update your configuration file to include your worker so you could use the tools directly from the client:
+
+```json
+{
+  "mcpServers": {
+    "your-mcp-server-name": {
+      "command": "/path/to/workers-mcp",
+      "args": [
+        "run",
+        "your-mcp-server-name",
+        "https://your-server-url.workers.dev",
+        "/path/to/your/project"
+      ],
+      "env": {}
+    }
+  }
+}
+
+Make sure to replace the placeholders with your actual server name, URL, and project path.
+
 ## Examples
 
 See the `examples` directory for a few ideas of what to use this for:


### PR DESCRIPTION
Added a new section explaining how to configure workers-mcp with Cursor, Windsurf, and other MCP clients.