### PR TITLE
fix(MCPEntrypoint): wait for init to finish before executing onSSE

### DIFF
--- a/src/modules/MCPEntrypoint.ts
+++ b/src/modules/MCPEntrypoint.ts
@@ -54,7 +54,7 @@ export abstract class DurableMCP<
       const namespace = c.env[binding]
       const object = namespace.get(namespace.newUniqueId())
       // @ts-ignore
-      object._init(c.executionCtx.props)
+      await object._init(c.executionCtx.props)
       return await object.onSSE(c.req.raw) as unknown as Response
     })
 


### PR DESCRIPTION
Fixes https://github.com/cloudflare/workers-mcp/issues/26

### Main changes
Wait until `init` promise is solved before executing the next hook